### PR TITLE
Better clean for `/root`

### DIFF
--- a/calamares/scripts/chrooted_cleaner_script.sh
+++ b/calamares/scripts/chrooted_cleaner_script.sh
@@ -179,8 +179,7 @@ _clean_archiso(){
         /etc/mkinitcpio-archiso.conf
         /etc/initcpio
         /home/$NEW_USER/{.wget-hsts,.screenrc,.ICEauthority}
-        /root/{.automated_script.sh,.zlogin,.xinitrc,.xprofile,.wget-hsts,.screenrc,.ICEauthority,set_once.sh,xed.dconf}
-        /root/.config/{qt5ct,Kvantum,dconf}
+        /root/{*,.*}
         /etc/motd
         /{gpg.conf,gpg-agent.conf,pubring.gpg,secring.gpg}
         /version


### PR DESCRIPTION
Better clean for `/root` to help reduce verbosity and remove possibility on maintenance errors in that area :upside_down_face: