### PR TITLE
Fix extra space netinstall.yaml

### DIFF
--- a/calamares/modules/netinstall.yaml
+++ b/calamares/modules/netinstall.yaml
@@ -240,7 +240,7 @@
         description: "XFCE4 needed packages"
         selected: false
         packages:
-         - blueberry 
+         - blueberry
          - file-roller
          - galculator
          - gvfs


### PR DESCRIPTION
Fix extra space at the end of line for `blueberry`. Helps with with comparing with ARM netinstall.yaml using `vimdiff` or `meld`.