### PR TITLE
WIP: Allow adding CA Cert to chroot image

### DIFF
--- a/calamares-extra-modules/src/modules/README.md
+++ b/calamares-extra-modules/src/modules/README.md
@@ -15,7 +15,7 @@
 5. packages
 
 6. **pacstrap:**
-   This module is uniowue to EndeavourOS, and the pure online install method to be close to arch we are using pacstrap for the initial system creation.
+   This module is unique to EndeavourOS, and the pure online install method to be close to arch we are using pacstrap for the initial system creation.
 
 7. **userpkglist:**
   This module is unique to EndeavourOS, and used on the implementation for users to add a list of packages that will get installed in addition to the         system on install process. 

--- a/calamares/modules/pacstrap.conf
+++ b/calamares/modules/pacstrap.conf
@@ -59,6 +59,7 @@ basePackages:
   - xfsprogs
   - xterm
   - mkinitcpio
+  - ca-certificates
 
 #
 # postInstallFiles is an array of file names which will be copied into the system

--- a/calamares/modules/shellprocess_initialize_pacman.conf
+++ b/calamares/modules/shellprocess_initialize_pacman.conf
@@ -19,7 +19,7 @@ script:
  - "cp /etc/pacman.d/mirrorlist @@ROOT@@/etc/pacman.d/"
  - "cp -a /etc/pacman.d/gnupg @@ROOT@@/etc/pacman.d/"
  - "cp /etc/resolv.conf @@ROOT@@/etc/"
- - "cp /etc/ca-certificates/trust-source/anchors/* @@ROOT@@/etc/ca-certificates/trust-source/anchors/"
+ - "cp -r /etc/ca-certificates/trust-source/anchors @@ROOT@@/etc/ca-certificates/trust-source/"
 
 i18n:
  name: "initialize pacman ... ranking mirrors ... copy pacman mirrorlist and keyring to target ..."

--- a/calamares/modules/shellprocess_initialize_pacman.conf
+++ b/calamares/modules/shellprocess_initialize_pacman.conf
@@ -19,6 +19,7 @@ script:
  - "cp /etc/pacman.d/mirrorlist @@ROOT@@/etc/pacman.d/"
  - "cp -a /etc/pacman.d/gnupg @@ROOT@@/etc/pacman.d/"
  - "cp /etc/resolv.conf @@ROOT@@/etc/"
+ - "cp /etc/ca-certificates/trust-source/anchors/* @@ROOT@@/etc/ca-certificates/trust-source/anchors/"
 
 i18n:
  name: "initialize pacman ... ranking mirrors ... copy pacman mirrorlist and keyring to target ..."

--- a/calamares/modules/shellprocess_update_tls_store.conf
+++ b/calamares/modules/shellprocess_update_tls_store.conf
@@ -1,0 +1,26 @@
+
+# SPDX-FileCopyrightText: no
+# SPDX-License-Identifier: CC0-1.0
+#
+# shellprocess_update_tls_store.conf
+# update TLS trust store if extra CA's are added 
+
+---
+
+dontChroot: false
+
+script:
+ - "update-ca-trust extract"
+
+i18n:
+ name: "Update TLS trust..."
+ name[de]: "Aktualisieren Sie das TLS-Vertrauen..."
+ name[fi]: "Päivitä TLS-luottamus..."
+ name[fr]: "Mettre à jour l'approbation TLS..."
+ name[it]: "Aggiorna l'attendibilità di TLS..."
+ name[es]: "Actualizar la confianza TLS..."
+ name[ru]: "обновить доверие TLS..."
+ name[zh_CN]: "更新 TLS 信任..."
+ name[ja]: "TLSの信頼を更新する..."
+ name[sv]: "Uppdatera TLS-förtroende..."
+ name[pt_BR]: "Atualizar a confiança TLS..."

--- a/calamares/settings_community.conf
+++ b/calamares/settings_community.conf
@@ -49,7 +49,11 @@ instances:
 - id:       copyfiles
   module:   shellprocess
   config:   shellprocess_copyfiles.conf
-  
+
+- id:       update_tls_store
+  module:   shellprocess
+  config:   shellprocess_update_tls_store.conf
+
 sequence:
 - show:
   - welcome@online
@@ -71,6 +75,7 @@ sequence:
   - locale
   - keyboard
   - localecfg
+  - shellprocess@update_tls_store
   - userpkglist
   - packages@online
   - luksbootkeyfile

--- a/calamares/settings_online.conf
+++ b/calamares/settings_online.conf
@@ -42,7 +42,11 @@ instances:
 - id:       copyfiles
   module:   shellprocess
   config:   shellprocess_copyfiles.conf
-  
+
+- id:       update_tls_store
+  module:   shellprocess
+  config:   shellprocess_update_tls_store.conf
+
 sequence:
 - show:
   - welcome@online
@@ -64,6 +68,7 @@ sequence:
   - locale
   - keyboard
   - localecfg
+  - shellprocess@update_tls_store
   - userpkglist
   - packages@online
   - luksbootkeyfile


### PR DESCRIPTION
This copies files from the live system trust store to the new system
trust store and updates the system trusts in the chroot so that any
required CAs can be added during install by users.

I have added translations using an online tool but I'm not sure how
accurate they are.

I also made a small typo fix in
calamares-extra-modules/src/modules/README.md

I have not tested this and may need help from maintainers to figure out how to do so.