### PR TITLE
Update Budgie desktop description in netinstall

### DIFF
--- a/calamares/modules/netinstall.yaml
+++ b/calamares/modules/netinstall.yaml
@@ -458,7 +458,7 @@
     - x-apps
     - xdg-user-dirs-gtk
 - name: "Budgie-Desktop"
-  description: "Budgie - I Tawt I Taw A Purdy Desktop"
+  description: "Budgie - an independent, familiar, and modern desktop."
   hidden: false
   selected: false
   critical: true


### PR DESCRIPTION
The "I Tawt I Taw A Purdy Desktop" description doesn't really describe the Budgie desktop, as it's just a copy of the old GitHub repository's description. This updates it to something more in line with the other desktop descriptions.